### PR TITLE
Rewrite large IN conditions

### DIFF
--- a/Delete.php
+++ b/Delete.php
@@ -7,4 +7,6 @@ use Drupal\Core\Database\Query\Delete as QueryDelete;
 /**
  * Oracle implementation of \Drupal\Core\Database\Query\Delete.
  */
-class Delete extends QueryDelete {}
+class Delete extends QueryDelete {
+  use OracleQueryTrait;
+}

--- a/Merge.php
+++ b/Merge.php
@@ -9,6 +9,8 @@ use Drupal\Core\Database\Query\Merge as QueryMerge;
  */
 class Merge extends QueryMerge {
 
+  use OracleQueryTrait;
+
   /**
    * {@inheritdoc}
    */

--- a/OracleQueryTrait.php
+++ b/OracleQueryTrait.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Drupal\Driver\Database\oracle;
+
+use Drupal\Core\Database\Query\SelectInterface;
+
+trait OracleQueryTrait {
+
+  /**
+   * @inheritDoc
+   */
+  public function preExecute($query = NULL) {
+    // First, let modules alter the query.
+    $return = parent::preExecute($query);
+
+    // If no query object is passed in, use $this.
+    if (!isset($query)) {
+      $query = $this;
+    }
+
+    // Split large IN statements.
+    foreach ($query->conditions() as $index => &$condition) {
+      $this->splitIn($condition);
+    }
+
+    return $return;
+  }
+
+  /**
+   * Oracle can't parse 1000+ items in an IN clause.
+   * Use multiple OR workaround https://stackoverflow.com/a/26223818/265501.
+   *
+   * @param $condition
+   * @return array
+   *   Multiple IN clauses conjoined by OR.
+   */
+  public function splitIn(&$condition) {
+    // The environment variable below is useful for testing/debugging.
+    $max_size = getenv('ORACLE_IN_MAX_SIZE') ?: 999;
+    if (isset($condition['operator']) && $condition['operator'] == 'IN' && count($condition['value']) > $max_size) {
+      $chunks = array_chunk($condition['value'], $max_size);
+      $group = $this->orConditionGroup();
+      foreach ($chunks as $chunk) {
+        $group->condition($condition['field'], $chunk, 'IN');
+      }
+      $condition = [
+        'field' => $group,
+        'value' => NULL,
+        'operator' => '=',
+      ];
+    }
+  }
+}

--- a/Select.php
+++ b/Select.php
@@ -10,6 +10,8 @@ use Drupal\Core\Database\Query\SelectInterface;
  */
 class Select extends QuerySelect {
 
+  use OracleQueryTrait;
+
   /**
    * {@inheritdoc}
    */

--- a/Update.php
+++ b/Update.php
@@ -11,6 +11,8 @@ use Drupal\Core\Database\Query\SelectInterface;
  */
 class Update extends QueryUpdate {
 
+  use OracleQueryTrait;
+
   /**
    * {@inheritdoc}
    */


### PR DESCRIPTION
Uses multiple OR clause approach per https://stackoverflow.com/questions/17842453/is-there-a-workaround-for-ora-01795-maximum-number-of-expressions-in-a-list-is.

Below is a file for testing. Run it with: `ORACLE_IN_MAX_SIZE=2 drush scr ../tmp.php`

```
<?php

use Drupal\Core\Database\Database;

$connection = Database::getConnection();
Database::startLog('tmp');
$result = $connection->select('users_field_data', 'u')
  ->fields('u', ['uid', 'name'])
  ->condition('name', ['Circus Dev', 'foo', 'bar', 'baz', 'Circus Admin'], 'IN')
  ->execute()
  ->fetchAll();
$log = Database::getLog('tmp');

print_r($result);
print_r($log[0]['query']);
print_r($log[0]['args']);
```

And my output:

```
Array
(
    [0] => stdClass Object
        (
            [uid] => 1
            [name] => Circus Admin
        )

    [1] => stdClass Object
        (
            [uid] => 187
            [name] => Circus Dev
        )

)
SELECT u."UID" AS "UID", u.name AS name
FROM
"USERS_FIELD_DATA" u
WHERE (name IN (:db_condition_placeholder_0, :db_condition_placeholder_1)) OR (name IN (:db_condition_placeholder_2, :db_condition_placeholder_3)) OR (name IN (:db_condition_placeholder_4))Array
(
    [:db_condition_placeholder_0] => Circus Dev
    [:db_condition_placeholder_1] => foo
    [:db_condition_placeholder_2] => bar
    [:db_condition_placeholder_3] => baz
    [:db_condition_placeholder_4] => Circus Admin
)
```